### PR TITLE
remove demangling logic

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,3 @@
 module github.com/lfi-project/lfi-bind
 
 go 1.24.3
-
-require github.com/ianlancetaylor/demangle v0.0.0-20250628045327-2d64ad6b7ec5

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,0 @@
-github.com/ianlancetaylor/demangle v0.0.0-20250628045327-2d64ad6b7ec5 h1:QCtizt3VTaANvnsd8TtD/eonx7JLIVdEKW1//ZNPZ9A=
-github.com/ianlancetaylor/demangle v0.0.0-20250628045327-2d64ad6b7ec5/go.mod h1:gx7rwoVhcfuVKG5uya9Hs3Sxj7EIvldVofAWIUtGouw=


### PR DESCRIPTION
We aren't using this right now so we should drop the dependency. We can consider re-adding this support, possibly in another way, when we add support for more C++ features.