### PR TITLE
Embed library bug fixes

### DIFF
--- a/embed/lib_init.c.in
+++ b/embed/lib_init.c.in
@@ -84,9 +84,8 @@ void *
 {{.lib}}_stack_push(size_t size)
 {
     struct LFIRegs *regs = lfi_ctx_regs({{.lib}}_ctx);
-    lfiptr sp = regs->REG_SP;
-    regs->REG_SP = sp - size;
-    return (void *) lfi_box_l2p({{.lib}}_box, sp);
+    regs->REG_SP = regs->REG_SP - size;
+    return (void *) lfi_box_l2p({{.lib}}_box, regs->REG_SP);
 }
 
 void *
@@ -280,7 +279,7 @@ init(void)
     };
 
     struct LFILinuxThread *t = lfi_thread_new(proc,
-        sizeof(argv)/sizeof(argv[0]), &argv[0], &envp[0]);
+        sizeof(argv)/sizeof(argv[0]) - 1, &argv[0], &envp[0]);
     if (!t)
         ERROR("failed to initialize LFI thread");
     int result = lfi_thread_run(t);


### PR DESCRIPTION
- Ignore the terminal NULL element in argv when computing argc.
- Return the decremented stack pointer to the newly pushed value in stack_push.