### PR TITLE
Add BTI GNU Note for *.S.in

### DIFF
--- a/embed/lib.inc.s.in
+++ b/embed/lib.inc.s.in
@@ -6,4 +6,19 @@
     .incbin "{{.lib_path}}"
 {{.lib}}_end:
 
+#ifndef __APPLE__
 .section .note.GNU-stack,"",@progbits
+
+// GNU property note for BTI and PAC support
+.pushsection .note.gnu.property, "a"
+.balign 8
+.long 4           // namesz
+.long 0x10        // descsz
+.long 5           // type: NT_GNU_PROPERTY_TYPE_0
+.asciz "GNU"      // name
+.long 0xc0000000  // GNU_PROPERTY_AARCH64_FEATURE_1_AND
+.long 4           // pr_datasz
+.long 3           // GNU_PROPERTY_AARCH64_FEATURE_1_BTI | GNU_PROPERTY_AARCH64_FEATURE_1_PAC
+.long 0           // padding
+.popsection
+#endif

--- a/embed/lib_trampolines.S.in
+++ b/embed/lib_trampolines.S.in
@@ -126,4 +126,19 @@
     .quad 0
 {{- end}}
 
+#ifndef __APPLE__
 .section .note.GNU-stack,"",@progbits
+
+// GNU property note for BTI and PAC support
+.pushsection .note.gnu.property, "a"
+.balign 8
+.long 4           // namesz
+.long 0x10        // descsz
+.long 5           // type: NT_GNU_PROPERTY_TYPE_0
+.asciz "GNU"      // name
+.long 0xc0000000  // GNU_PROPERTY_AARCH64_FEATURE_1_AND
+.long 4           // pr_datasz
+.long 3           // GNU_PROPERTY_AARCH64_FEATURE_1_BTI | GNU_PROPERTY_AARCH64_FEATURE_1_PAC
+.long 0           // padding
+.popsection
+#endif


### PR DESCRIPTION
When the *.S files are generated by lfi-bind, they do not have the GNU Note for BTI causing `ld.lld` errors with `-z bti-report` like this one: 
```
ld.lld: error: (trampolines.o): -z bti-report: file does not have GNU_PROPERTY_AARCH64_FEATURE_1_BTI property
```