### PR TITLE
Add `-dir-maps` command-line flag

### DIFF
--- a/embed/lib_init.c.in
+++ b/embed/lib_init.c.in
@@ -203,7 +203,9 @@ getfilepath(const char *path)
 
 {{end}}
 
+{{if or .dir_maps .dynamic}}
 static char cwd[FILENAME_MAX];
+{{end}}
 
 {{if .dynamic}}
 static const char *all[] = {
@@ -227,11 +229,13 @@ static const char *dir_maps[] = {
 static bool
 lfi_init(void)
 {
+{{if or .dir_maps .dynamic}}
     char *p = getcwd(cwd, sizeof(cwd));
     if (p != cwd) {
         LOG("error: failed to read cwd");
         return false;
     }
+{{end}}
 
     // Create engine if it does not exist.
     bool ok = lfi_linux_lib_init((struct LFIOptions) {

--- a/embed/lib_init.c.in
+++ b/embed/lib_init.c.in
@@ -203,11 +203,23 @@ getfilepath(const char *path)
 
 {{end}}
 
-{{if .dynamic}}
 static char cwd[FILENAME_MAX];
 
+{{if .dynamic}}
 static const char *all[] = {
     "/=/",
+    NULL,
+};
+{{end}}
+
+{{if .dir_maps}}
+static const char *dir_maps[] = {
+{{- range $map := .dir_maps}}
+    "{{$map}}",
+{{- end}}
+{{- if .dynamic}}
+    "/=/",
+{{- end}}
     NULL,
 };
 {{end}}
@@ -215,13 +227,11 @@ static const char *all[] = {
 static bool
 lfi_init(void)
 {
-{{if .dynamic}}
     char *p = getcwd(cwd, sizeof(cwd));
     if (p != cwd) {
         LOG("error: failed to read cwd");
         return false;
     }
-{{end}}
 
     // Create engine if it does not exist.
     bool ok = lfi_linux_lib_init((struct LFIOptions) {
@@ -238,7 +248,10 @@ lfi_init(void)
 {{end}}
     }, (struct LFILinuxOptions) {
         .stacksize = 2UL * 1024 * 1024,
-{{if .dynamic}}
+{{if .dir_maps}}
+        .dir_maps = dir_maps,
+        .wd = cwd,
+{{else if .dynamic}}
         // TODO: don't allow complete file system access if dynamic...
         .dir_maps = all,
         .wd = cwd,

--- a/main.go
+++ b/main.go
@@ -149,6 +149,7 @@ type Options struct {
 	Constructor    bool
 	Verbose        bool
 	NoSigaltstack  bool
+	DirMaps     []string
 	StackArgs   map[string]StackArgInfo
 }
 
@@ -246,6 +247,7 @@ func GenInit(file string, opts Options) {
 		"constructor": opts.Constructor,
 		"verbose":         opts.Verbose,
 		"no_sigaltstack":  opts.NoSigaltstack,
+		"dir_maps":        opts.DirMaps,
 	}, nil)
 
 	w.Close()
@@ -280,6 +282,7 @@ func main() {
 	noConstructor := flag.Bool("no-constructor", false, "disable constructor for automatic initialization")
 	verbose := flag.Bool("verbose", false, "enable verbose logging")
 	noSigaltstack := flag.Bool("no-sigaltstack", false, "disable automatic sigaltstack initialization")
+	dirMaps := flag.String("dir-maps", "", "comma-separated list of directory mappings (e.g. /=/)")
 
 	flag.Parse()
 
@@ -358,6 +361,11 @@ func main() {
 	}
 	f.Close()
 
+	var dirMapsSlice []string
+	if *dirMaps != "" {
+		dirMapsSlice = strings.Split(*dirMaps, ",")
+	}
+
 	opts := Options{
 		Input:       input,
 		Syms:        syms,
@@ -370,6 +378,7 @@ func main() {
 		Constructor: !*noConstructor,
 		Verbose:       *verbose,
 		NoSigaltstack: *noSigaltstack,
+		DirMaps:     dirMapsSlice,
 		StackArgs:   stackArgs,
 	}
 


### PR DESCRIPTION
Add `-dir-maps` flag to `main.go` for passing comma-separated directory mappings (e.g., `-dir-maps=/=/`) to `lib_init.c.in`.

If `dir_maps` is omitted and `dynamic` is true, fallback to static `all[]` (`/=/`). If both are set, append `"/=/"` to the provided mappings.

This allows non-dynamic libraries filesystem access. 

(Historically, `.dir_maps` and `.wd` were added with `dynamic` in `483bfdf` because dynamic libraries required filesystem access for `dlopen`. This change generalizes mapping configuration for all targets.)